### PR TITLE
Fix documentation for Remove-TeamViewerDuplicateDevicesV2 example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ A continously growing set of Powershell example scripts that showcase the
 * 📜 Sets the policy for all / specific devices to specific policy or inherits policy from group.
 * ⚙️ [TeamViewerPS](https://github.com/teamviewer/TeamViewerPS) module needed
 
+### [Remove-TeamViewerDuplicateDevicesV2](./Remove-TeamViewerDuplicateDevicesV2)
+
+* 📜 Removes TeamViewer devices (MDv2) that have a duplicate counterpart in the same company.
+* ⚙️ [TeamViewerPS](https://github.com/teamviewer/TeamViewerPS) module needed
+
 ### [Remove-TeamViewerOutdatedDevice](./Remove-TeamViewerOutdatedDevice)
 
 * 📜 Removes TeamViewer devices (MDv1) that didn't appear online for a given time.
@@ -27,7 +32,7 @@ A continously growing set of Powershell example scripts that showcase the
 * 📜 Removes TeamViewer devices (MDv2) that didn't appear online for a given time.
 * ⚙️ [TeamViewerPS](https://github.com/teamviewer/TeamViewerPS) module needed
 
-### [Import-TeamViewerUser](./Import-TeamViewerUser):
+### [Import-TeamViewerUser](./Import-TeamViewerUser)
 
 * 📜 Imports and updates a set of users from a CSV file into the TeamViewer company.
 * ⚙️ [TeamViewerPS](https://github.com/teamviewer/TeamViewerPS) module needed

--- a/Remove-TeamViewerDuplicateDevicesV2/Remove-TeamViewerDuplicateDevicesV2.ps1
+++ b/Remove-TeamViewerDuplicateDevicesV2/Remove-TeamViewerDuplicateDevicesV2.ps1
@@ -11,7 +11,7 @@
  .PARAMETER ApiToken
     The TeamViewer API token to use.
     Must be a user access token.
-    The token requires the following access permissions: company admin
+    The token requires the following access permissions: company admin, Device Groups: read and write operations
 
  .PARAMETER Force
     If set, the script will NOT ask the user for confirmation of the removal.


### PR DESCRIPTION
The script targets two endpoints (one for getting the company devices, one for deleting them), which require read and modify operation permissions on Device Groups for the given Api token. Fixed documentation to reflect that.
Also added the example script in the README of the repo.