### PR TITLE
Removed references to deprecated legacy permissions.

### DIFF
--- a/Import-TeamViewerUser/Import-TeamViewerUser.ps1
+++ b/Import-TeamViewerUser/Import-TeamViewerUser.ps1
@@ -32,10 +32,6 @@
  .PARAMETER DefaultUserPassword
     The fallback user password used for creating new users. This value is only considered if not given in the CSV or pipeline user data.
 
- .PARAMETER DefaultUserPermissions
-    The fallback user permissions used for creating new users. This value is only considered if not given in the CSV or pipeline user data.
-    Must be a comma-separated list of user permissions, see the "TeamViewer API Documentation" for valid inputs.
-
  .PARAMETER DefaultSsoCustomerId
     The fallback SSO customer ID, used for creating new users that are already enabled and activated for SSO logins.
     This value is only considered if not given in the CSV or pipeline user data.
@@ -94,9 +90,6 @@ param(
 
     [Parameter(Mandatory = $false)]
     [securestring] $DefaultUserPassword,
-
-    [Parameter(Mandatory = $false)]
-    [string[]] $DefaultUserPermissions = @('ShareOwnGroups', 'EditConnections', 'EditFullProfile', 'ViewOwnConnections'),
 
     [Parameter(Mandatory = $false)]
     [securestring] $DefaultSsoCustomerId
@@ -170,13 +163,6 @@ function Import-TeamViewerUser {
                 }
                 else {
                     $additionalParameters['WithoutPassword'] = $true
-                }
-
-                if ($user.permissions) {
-                    $additionalParameters['Permissions'] = $user.permissions -split ','
-                }
-                elseif ($DefaultUserPermissions) {
-                    $additionalParameters['Permissions'] = $DefaultUserPermissions
                 }
 
                 if ($user.language) {

--- a/Import-TeamViewerUser/example.csv
+++ b/Import-TeamViewerUser/example.csv
@@ -1,3 +1,3 @@
-﻿email,name,password,permissions,language
-user1@example.test,User1,TestPassword123,"ShareOwnGroups,EditConnections,EditFullProfile,ViewOwnConnections",en
-user2@example.test,User2,TestPassword123,"ShareOwnGroups,EditConnections,EditFullProfile,ViewOwnConnections",en
+﻿email,name,password,language
+user1@example.test,User1,TestPassword123,en
+user2@example.test,User2,TestPassword123,en


### PR DESCRIPTION
The legacy permissions (also known as rights) are today replaced with roles. Thus the references to this has now also be removed from the API sample scripts.